### PR TITLE
Ck remove unnecessary compile include directories

### DIFF
--- a/python/aitemplate/backend/rocm/conv2d/conv2d_bias_add_relu.py
+++ b/python/aitemplate/backend/rocm/conv2d/conv2d_bias_add_relu.py
@@ -26,7 +26,7 @@ EXTRA_CODE = jinja2.Template(
     """
 #include "ck/tensor_operation/gpu/device/device_grouped_conv_fwd_multiple_d_xdl_cshuffle.hpp"
 
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/conv2d/conv2d_bias_sigmoid.py
+++ b/python/aitemplate/backend/rocm/conv2d/conv2d_bias_sigmoid.py
@@ -26,7 +26,7 @@ EXTRA_CODE = jinja2.Template(
     """
 #include "ck/tensor_operation/gpu/device/device_grouped_conv_fwd_multiple_d_xdl_cshuffle.hpp"
 
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/bmm_softmax_bmm.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_softmax_bmm.py
@@ -25,7 +25,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 const ck::half_t alpha = {{scale}};
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add.py
@@ -27,7 +27,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add.py
@@ -27,7 +27,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add_relu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add_relu.py
@@ -27,7 +27,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_relu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_relu.py
@@ -27,7 +27,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul.py
@@ -27,7 +27,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_add.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_add.py
@@ -26,7 +26,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_tanh.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_tanh.py
@@ -27,7 +27,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid.py
@@ -28,7 +28,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul.py
@@ -27,7 +27,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul_tanh.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul_tanh.py
@@ -27,7 +27,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_tanh.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_tanh.py
@@ -28,7 +28,7 @@ from .layout import RCR
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "data_type.hpp"
+#include "ck/utility/data_type.hpp"
 
 namespace ck {
 namespace tensor_operation {

--- a/python/aitemplate/backend/rocm/target_def.py
+++ b/python/aitemplate/backend/rocm/target_def.py
@@ -93,7 +93,6 @@ class ROCM(Target):
         ck_paths = [
             os.path.join(self._template_path),
             os.path.join(self._template_path, "include/"),
-            os.path.join(self._template_path, "include/ck/utility"),
             os.path.join(self._template_path, "external/include/half/"),
             os.path.join(self._template_path, "library/include/"),
             os.path.join(self._template_path, "profiler/include/"),

--- a/python/aitemplate/backend/rocm/target_def.py
+++ b/python/aitemplate/backend/rocm/target_def.py
@@ -93,55 +93,9 @@ class ROCM(Target):
         ck_paths = [
             os.path.join(self._template_path),
             os.path.join(self._template_path, "include/"),
-            os.path.join(self._template_path, "include/ck/"),
-            os.path.join(self._template_path, "include/ck/problem_transform/"),
-            os.path.join(self._template_path, "include/ck/tensor/"),
-            os.path.join(self._template_path, "include/ck/tensor_description/"),
-            os.path.join(self._template_path, "include/ck/tensor_operation/"),
-            os.path.join(self._template_path, "include/ck/tensor_operation/gpu/block/"),
-            os.path.join(
-                self._template_path, "include/ck/tensor_operation/gpu/device/"
-            ),
-            os.path.join(
-                self._template_path, "include/ck/tensor_operation/gpu/device/impl/"
-            ),
-            os.path.join(
-                self._template_path, "include/ck/tensor_operation/gpu/element/"
-            ),
-            os.path.join(self._template_path, "include/ck/tensor_operation/gpu/grid/"),
-            os.path.join(
-                self._template_path, "include/ck/tensor_operation/gpu/thread/"
-            ),
-            os.path.join(self._template_path, "include/ck/tensor_operation/gpu/warp/"),
-            os.path.join(self._template_path, "include/ck/utility/"),
-            os.path.join(self._template_path, "include/ck/host_utility"),
+            os.path.join(self._template_path, "include/ck/utility"),
             os.path.join(self._template_path, "external/include/half/"),
-            os.path.join(self._template_path, "library/include/ck/library/host/"),
-            os.path.join(
-                self._template_path, "library/include/ck/library/host_tensor/"
-            ),
-            os.path.join(
-                self._template_path,
-                "library/include/ck/library/obselete_driver_offline/",
-            ),
-            os.path.join(
-                self._template_path,
-                "library/include/ck/library/reference_tensor_operation/cpu/",
-            ),
-            os.path.join(
-                self._template_path,
-                "library/include/ck/library/reference_tensor_operation/gpu/",
-            ),
-            os.path.join(
-                self._template_path,
-                "library/include/ck/library/tensor_operation_instance/",
-            ),
-            os.path.join(
-                self._template_path,
-                "library/include/ck/library/tensor_operation_instance/gpu/" + "reduce/",
-            ),
-            os.path.join(self._template_path, "library/include/ck/library/tensor_op/"),
-            os.path.join(self._template_path, "library/include/ck/library/utility/"),
+            os.path.join(self._template_path, "library/include/"),
             os.path.join(self._template_path, "profiler/include/"),
         ]
         options = [


### PR DESCRIPTION
originally there are a lot of include directory needed inside `_build_compile_options()` which makes hard to maintain, and some of the path is wrong (because ck code always include starting from `ck/xxx`).
Now only need to tell compiler to include 4 directories.