### PR TITLE
correct gemm stride for concat fusion

### DIFF
--- a/python/aitemplate/backend/rocm/gemm/common.py
+++ b/python/aitemplate/backend/rocm/gemm/common.py
@@ -26,12 +26,21 @@ from ...common import gemm_common
 from ...target import Target
 
 # pylint: disable=C0103,C0415,W0611,C0301
+OUTPUT_ADDR_CALCULATOR = jinja2.Template(
+    """
+  {% if output_accessor.is_from_strided_tensor %}
+    output_stride = {{output_accessor.actual_total_elements_from_stride_dim}};
+    output_offset = {{output_accessor.offset}};
+  {% endif %}
+    """
+)
 
 EXTRA_SHAPE_TEMPLATE = jinja2.Template(
     """
 {{indent}}const int64_t stride_a = *a_dim1;
 {{indent}}const int64_t stride_b = *b_dim1;
 {{indent}}const int64_t stride_c = *c_dim1;
+{{indent}}int64_t output_stride = stride_c;
 """
 )
 
@@ -42,6 +51,7 @@ INSTANCE_TEMPLATE = jinja2.Template(
 using {{name}} = {{ config_name }};
 """
 )
+
 
 EXEC_TEMPLATE = jinja2.Template(
     """
@@ -134,6 +144,7 @@ void {{function_name}}(
     hipStream_t stream
     ) {
   {{shape_func}}
+  int64_t output_offset = 0;
   {{extra_shape}}
   {{input_addr_calculator}}
   {{output_addr_calculator}}
@@ -202,7 +213,7 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
                                                                     static_cast<ck::half_t *>(d1_ptr)},
 {% endif %}
 {% endif %}
-{{indent}}                                static_cast<ck::half_t *>(out_ptr),
+{{indent}}                                static_cast<ck::half_t *>(out_ptr) + output_offset,
 {% if gemm_flag not in ["permute_m2n3", "bias_permute_m2n3", "bias_permute_m3n2"]  %}
 {{indent}}                                M,
 {{indent}}                                N,
@@ -235,7 +246,7 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 {% elif has_d1 %}
 {{indent}}                                std::array<ck::index_t, 3>{0, static_cast<int>(stride_c), static_cast<int>(stride_c)},
 {% endif %}
-{{indent}}                                stride_c,
+{{indent}}                                output_stride,
 {% endif %}
 {{indent}}                                ck::tensor_operation::element_wise::PassThrough{},
 {{indent}}                                ck::tensor_operation::element_wise::PassThrough{},

--- a/python/aitemplate/backend/rocm/gemm/common.py
+++ b/python/aitemplate/backend/rocm/gemm/common.py
@@ -27,10 +27,14 @@ from ...target import Target
 
 INPUT_ADDR_CALCULATOR = jinja2.Template(
     """
-  stride_a = {{accessor_a.stride(1)}};
-  offset_a = {{accessor_a.offset}}; // default to 0
-  stride_b = {{accessor_b.stride(1)}};
-  offset_b = {{accessor_b.offset}}; // default to 0
+    {% if accessor_a.is_from_strided_tensor %}
+      stride_a = {{accessor_a.stride(0)}};
+      offset_a = {{accessor_a.offset}}; // default to 0
+    {% endif %}
+    {% if accessor_b.is_from_strided_tensor %}
+      stride_b = {{accessor_b.stride(0)}};
+      offset_b = {{accessor_b.offset}}; // default to 0
+    {% endif %}
     """
 )
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr.py
@@ -90,7 +90,9 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
     str
         The rendered template of generated function body.
     """
-    return common.gen_function(func_attrs, exec_cond_template, dim_info_dict, "")
+    return common.gen_function(func_attrs, exec_cond_template, dim_info_dict, "",
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]))
 
 
 @registry.reg("rocm.gemm_rcr.func_decl")

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias.py
@@ -90,7 +90,9 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
     str
         The rendered template of generated function body.
     """
-    return common.gen_function(func_attrs, exec_cond_template, dim_info_dict, "bias", output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]))
+    return common.gen_function(func_attrs, exec_cond_template, dim_info_dict, "bias",
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]))
 
 
 @registry.reg("rocm.gemm_rcr_bias.func_decl")

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias.py
@@ -90,7 +90,7 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
     str
         The rendered template of generated function body.
     """
-    return common.gen_function(func_attrs, exec_cond_template, dim_info_dict, "bias")
+    return common.gen_function(func_attrs, exec_cond_template, dim_info_dict, "bias", output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]))
 
 
 @registry.reg("rocm.gemm_rcr_bias.func_decl")

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add.py
@@ -127,6 +127,8 @@ def gen_function(
         dim_info_dict,
         "bias_add",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add.py
@@ -127,6 +127,8 @@ def gen_function(
         dim_info_dict,
         "bias_add_add",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add_relu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add_relu.py
@@ -128,6 +128,8 @@ def gen_function(
         dim_info_dict,
         "bias_add_add_relu",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_relu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_relu.py
@@ -128,6 +128,8 @@ def gen_function(
         dim_info_dict,
         "bias_add_relu",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0])
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_fast_gelu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_fast_gelu.py
@@ -95,6 +95,7 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
         exec_cond_template,
         dim_info_dict,
         "bias_fast_gelu",
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_fast_gelu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_fast_gelu.py
@@ -95,6 +95,7 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
         exec_cond_template,
         dim_info_dict,
         "bias_fast_gelu",
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
         output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul.py
@@ -127,6 +127,8 @@ def gen_function(
         dim_info_dict,
         "bias_mul",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_add.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_add.py
@@ -98,6 +98,8 @@ def gen_function(
         dim_info_dict,
         "bias_mul_add",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_tanh.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_tanh.py
@@ -130,6 +130,8 @@ def gen_function(
         dim_info_dict,
         "bias_mul_tanh",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0])
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_relu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_relu.py
@@ -91,7 +91,9 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
         The rendered template of generated function body.
     """
     return common.gen_function(
-        func_attrs, exec_cond_template, dim_info_dict, "bias_relu"
+        func_attrs, exec_cond_template, dim_info_dict, "bias_relu",
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid.py
@@ -143,6 +143,8 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
         dim_info_dict,
         "bias_sigmoid",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul.py
@@ -129,6 +129,8 @@ def gen_function(
         dim_info_dict,
         "bias_sigmoid_mul",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul_tanh.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul_tanh.py
@@ -132,6 +132,8 @@ def gen_function(
         dim_info_dict,
         "bias_sigmoid_mul_tanh",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_swish.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_swish.py
@@ -96,6 +96,8 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
         exec_cond_template,
         dim_info_dict,
         "bias_swish",
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_tanh.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_tanh.py
@@ -145,6 +145,8 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
         dim_info_dict,
         "bias_tanh",
         extra_code=EXTRA_CODE.render(),
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),
     )
 
 

--- a/python/aitemplate/backend/rocm/gemm/gemm_rrr.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rrr.py
@@ -90,7 +90,9 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
     str
         The rendered template of generated function body.
     """
-    return common.gen_function(func_attrs, exec_cond_template, dim_info_dict, "")
+    return common.gen_function(func_attrs, exec_cond_template, dim_info_dict, "", 
+        input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(accessor_a=func_attrs["input_accessors"][0], accessor_b=func_attrs["input_accessors"][1]),
+        output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(output_accessor=func_attrs["output_accessors"][0]),)
 
 
 @registry.reg("rocm.gemm_rrr.func_decl")

--- a/python/aitemplate/backend/rocm/normalization/layernorm.py
+++ b/python/aitemplate/backend/rocm/normalization/layernorm.py
@@ -65,10 +65,15 @@ SHAPE_EVAL_TEMPLATE = jinja2.Template(
 EXEC_TEMPLATE = jinja2.Template(
     """
     std::vector<ck::index_t> i_inStrides;
+    std::vector<ck::index_t> i_outStrides;
 
-    i_inStrides.push_back(N);
-    i_inStrides.push_back(1);
+    {% for stride in input_strides %}
+        i_inStrides.push_back({{stride}});
+    {% endfor %}
 
+    {% for stride in output_strides %}
+        i_outStrides.push_back({{stride}});
+    {% endfor %}
 
     auto device_instance = {{instance}}{};
     auto argument_ptr = device_instance.MakeArgumentPointer(
@@ -76,13 +81,13 @@ EXEC_TEMPLATE = jinja2.Template(
         i_inStrides,
         std::vector<ck::index_t>{0, 1},
         std::vector<ck::index_t>{0, 1},
-        i_inStrides,
+        i_outStrides,
         {1},
         {{eps}},
-        static_cast<ck::half_t *>(input),
+        static_cast<ck::half_t *>(input) + {{input_offset}},
         static_cast<ck::half_t *>(gamma),
         static_cast<ck::half_t *>(beta),
-        static_cast<ck::half_t *>(output),
+        static_cast<ck::half_t *>(output) + {{output_offset}},
         ck::tensor_operation::element_wise::PassThrough{}
     );
 
@@ -235,6 +240,16 @@ def gen_function(
     """
     rank = func_attrs["inputs"][0]._rank()
     eps = func_attrs.get("eps", "1e-5")
+    input_accessor = func_attrs["input_accessors"][0]
+    output_accessor = func_attrs["output_accessors"][0]
+    input_strides = []
+    output_strides = []
+    for i, _ in enumerate(input_accessor.original_shapes):
+        input_strides.append(input_accessor.stride(i))
+        output_strides.append(output_accessor.stride(i))
+
+    input_offset = input_accessor.offset
+    output_offset = output_accessor.offset
 
     exec_path = func_attrs["exec_path"]
     op_instance = func_attrs["op_instance"]
@@ -264,7 +279,7 @@ def gen_function(
     for key, _ in instances.items():
         fname = "f" + sha1(key.encode()).hexdigest()
         program = exec_template.render(
-            instance=fname, dtype="void", reduce_dims=rank - 1, eps=eps
+            instance=fname, dtype="void", reduce_dims=rank - 1, eps=eps, input_strides=input_strides, output_strides=output_strides, input_offset=input_offset, output_offset=output_offset
         )
         exec_inst = exec_cond_template.render(indent="  ", cond=key, program=program)
         exec_paths += exec_inst
@@ -346,14 +361,6 @@ def layernorm_gen_function_call(func_attrs, indent="  "):
     ), f"LayerNorm only supports input with rank >= 2, current rank: {len(shapes)}"
 
     input_dim_names = [shape._attrs["name"] for shape in shapes]
-    x = func_attrs["inputs"][0]
-    xshape = x._attrs["shape"]
-
-    elem_cnt = 1
-    for shape in xshape:
-        elem_cnt *= shape._attrs["values"][0]
-    instance_size = xshape[-1]._attrs["values"][0]
-    instance_num = elem_cnt // instance_size
 
     return FUNC_CALL_TEMPLATE.render(
         func_name=func_attrs["name"],
@@ -361,8 +368,6 @@ def layernorm_gen_function_call(func_attrs, indent="  "):
         gamma=gamma_name,
         beta=beta_name,
         output=output_name,
-        M=instance_num,
-        N=instance_size,
         input_dim_names=input_dim_names,
         indent=indent,
     )

--- a/python/aitemplate/backend/rocm/normalization/layernorm.py
+++ b/python/aitemplate/backend/rocm/normalization/layernorm.py
@@ -66,14 +66,21 @@ EXEC_TEMPLATE = jinja2.Template(
     """
     std::vector<ck::index_t> i_inStrides;
     std::vector<ck::index_t> i_outStrides;
+    {% if input_strides is defined %}
+    i_inStrides.push_back({{input_strides[-2]}});
+    i_inStrides.push_back({{input_strides[-1]}});
+    {% else %}
+    i_inStrides.push_back(N);
+    i_inStrides.push_back(1);
+    {% endif %}
 
-    {% for stride in input_strides %}
-        i_inStrides.push_back({{stride}});
-    {% endfor %}
-
-    {% for stride in output_strides %}
-        i_outStrides.push_back({{stride}});
-    {% endfor %}
+    {% if output_strides is defined %}
+    i_outStrides.push_back({{output_strides[-2]}});
+    i_outStrides.push_back({{output_strides[-1]}});
+    {% else %}
+    i_outStrides.push_back(N);
+    i_outStrides.push_back(1);
+    {% endif %}
 
     auto device_instance = {{instance}}{};
     auto argument_ptr = device_instance.MakeArgumentPointer(
@@ -84,10 +91,10 @@ EXEC_TEMPLATE = jinja2.Template(
         i_outStrides,
         {1},
         {{eps}},
-        static_cast<ck::half_t *>(input) + {{input_offset}},
+        static_cast<ck::half_t *>(input) + {{ input_offset if input_offset is defined else 0 }},
         static_cast<ck::half_t *>(gamma),
         static_cast<ck::half_t *>(beta),
-        static_cast<ck::half_t *>(output) + {{output_offset}},
+        static_cast<ck::half_t *>(output) + {{ output_offset if output_offset is defined else 0 }},
         ck::tensor_operation::element_wise::PassThrough{}
     );
 

--- a/python/aitemplate/compiler/transform/transform_strided_ops.py
+++ b/python/aitemplate/compiler/transform/transform_strided_ops.py
@@ -479,6 +479,7 @@ def transform_strided_ops(
         funcs = [
             # Keep on ROCM
             _fuse_strided_op_and_view_op,
+            _fuse_strided_op_and_cat,
             _fuse_split_and_strided_op,
             _fuse_slices_concat,
         ]

--- a/python/aitemplate/compiler/transform/transform_strided_ops.py
+++ b/python/aitemplate/compiler/transform/transform_strided_ops.py
@@ -481,6 +481,7 @@ def transform_strided_ops(
             _fuse_strided_op_and_view_op,
             _fuse_strided_op_and_cat,
             _fuse_split_and_strided_op,
+            _fuse_slice_and_strided_op,
             _fuse_slices_concat,
         ]
     for func in funcs:


### PR DESCRIPTION
Bert performance(old):
output_0 shape: [32, 1024, 768]

batch_size: 32, seq_length: 1024, latency: 89.88082313537598

output_0 shape: [64, 1024, 768]

batch_size: 64, seq_length: 1024, latency: 181.42297744750977

output_0 shape: [128, 1024, 768]

batch_size: 128, seq_length: 1024, latency: 357.5509796142578

output_0 shape: [256, 1024, 768]

batch_size: 256, seq_length: 1024, latency: 745.2749176025391

Bert performance(new):
output_0 shape: [32, 1024, 768]

batch_size: 32, seq_length: 1024, latency: 89.81751441955566

output_0 shape: [64, 1024, 768]

batch_size: 64, seq_length: 1024, latency: 180.47053909301758

output_0 shape: [128, 1024, 768]

batch_size: 128, seq_length: 1024, latency: 357.5366973876953

output_0 shape: [256, 1024, 768]

batch_size: 256, seq_length: 1024, latency: 743.6724853515625


Unit performance tests
slice op fusion 0.01985735073685646ms->0.015206613577902317 ms
layernorm fusion 0.0848146378993988ms->0.08335678279399872ms