### PR TITLE
sync meta main (#8)

### DIFF
--- a/examples/05_stable_diffusion/benchmark.py
+++ b/examples/05_stable_diffusion/benchmark.py
@@ -288,7 +288,7 @@ def benchmark_diffusers(token, batch_size, verify, benchmark_pt):
         access_token = token
 
     pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4",
+        "runwayml/stable-diffusion-v1-5",
         revision="fp16",
         torch_dtype=torch.float16,
         use_auth_token=access_token,

--- a/examples/05_stable_diffusion/benchmark_pt.py
+++ b/examples/05_stable_diffusion/benchmark_pt.py
@@ -27,7 +27,7 @@ from diffusers import StableDiffusionPipeline
 )
 def run(token, prompt, benchmark):
     pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4",
+        "runwayml/stable-diffusion-v1-5",
         revision="fp16",
         torch_dtype=torch.float16,
         use_auth_token=token,

--- a/examples/05_stable_diffusion/compile.py
+++ b/examples/05_stable_diffusion/compile.py
@@ -316,11 +316,12 @@ def compile_vae(
 
 @click.command()
 @click.option("--token", default="", help="access token")
+@click.option("--width", default=512, help="Width of generated image")
+@click.option("--height", default=512, help="Height of generated image")
 @click.option("--batch-size", default=1, help="batch size")
-@click.option("--img2img", default=False, help="compile img2img models")
 @click.option("--use-fp16-acc", default=True, help="use fp16 accumulation")
 @click.option("--convert-conv-to-gemm", default=True, help="convert 1x1 conv to gemm")
-def compile_diffusers(token, batch_size, img2img=False, use_fp16_acc=True, convert_conv_to_gemm=True):
+def compile_diffusers(token, width, height, batch_size, use_fp16_acc=True, convert_conv_to_gemm=True):
     logging.getLogger().setLevel(logging.INFO)
     np.random.seed(0)
     torch.manual_seed(4896)
@@ -333,25 +334,27 @@ def compile_diffusers(token, batch_size, img2img=False, use_fp16_acc=True, conve
         access_token = token
 
     pipe = StableDiffusionPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4",
+        "runwayml/stable-diffusion-v1-5",
         revision="fp16",
         torch_dtype=torch.float16,
         use_auth_token=access_token,
     ).to("cuda")
 
-    width = 96 if img2img else 64
+    ww = width // 8
+    hh = height // 8
 
     # CLIP
     compile_clip(batch_size=batch_size, use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm)
     # UNet
     compile_unet(
         batch_size=batch_size * 2,
-        ww=width,
+        ww=ww,
+        hh=hh,
         use_fp16_acc=use_fp16_acc,
         convert_conv_to_gemm=convert_conv_to_gemm,
     )
     # VAE
-    compile_vae(batch_size=batch_size, width=width, use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm)
+    compile_vae(batch_size=batch_size, width=ww, height=hh, use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm)
 
 
 if __name__ == "__main__":

--- a/examples/05_stable_diffusion/demo.py
+++ b/examples/05_stable_diffusion/demo.py
@@ -21,20 +21,22 @@ from pipeline_stable_diffusion_ait import StableDiffusionAITPipeline
 
 @click.command()
 @click.option("--token", default="", help="access token")
+@click.option("--width", default=512, help="Width of generated image")
+@click.option("--height", default=512, help="Height of generated image")
 @click.option("--prompt", default="A vision of paradise, Unreal Engine", help="prompt")
 @click.option(
     "--benchmark", type=bool, default=False, help="run stable diffusion e2e benchmark"
 )
-def run(token, prompt, benchmark):
+def run(token, width, height, prompt, benchmark):
     pipe = StableDiffusionAITPipeline.from_pretrained(
-        "CompVis/stable-diffusion-v1-4",
+        "runwayml/stable-diffusion-v1-5",
         revision="fp16",
         torch_dtype=torch.float16,
         use_auth_token=token,
     ).to("cuda")
 
     with torch.autocast("cuda"):
-        image = pipe(prompt).images[0]
+        image = pipe(prompt, height, width).images[0]
         if benchmark:
             t = benchmark_torch_function(10, pipe, prompt)
             print(f"sd e2e: {t} ms")

--- a/examples/05_stable_diffusion/demo_img2img.py
+++ b/examples/05_stable_diffusion/demo_img2img.py
@@ -25,17 +25,19 @@ from pipeline_stable_diffusion_img2img_ait import StableDiffusionImg2ImgAITPipel
 
 @click.command()
 @click.option("--token", default="", help="access token")
+@click.option("--width", default=512, help="Width of generated image")
+@click.option("--height", default=512, help="Height of generated image")
 @click.option(
     "--prompt", default="A fantasy landscape, trending on artstation", help="prompt"
 )
 @click.option(
     "--benchmark", type=bool, default=False, help="run stable diffusion e2e benchmark"
 )
-def run(token, prompt, benchmark):
+def run(token, width, height, prompt, benchmark):
 
     # load the pipeline
     device = "cuda"
-    model_id_or_path = "CompVis/stable-diffusion-v1-4"
+    model_id_or_path = "runwayml/stable-diffusion-v1-5"
     pipe = StableDiffusionImg2ImgAITPipeline.from_pretrained(
         model_id_or_path,
         revision="fp16",
@@ -49,7 +51,7 @@ def run(token, prompt, benchmark):
 
     response = requests.get(url)
     init_image = Image.open(BytesIO(response.content)).convert("RGB")
-    init_image = init_image.resize((768, 512))
+    init_image = init_image.resize((height, width))
 
     with torch.autocast("cuda"):
         images = pipe(

--- a/examples/05_stable_diffusion/pipeline_stable_diffusion_ait.py
+++ b/examples/05_stable_diffusion/pipeline_stable_diffusion_ait.py
@@ -60,7 +60,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
             [`DDIMScheduler`], [`LMSDiscreteScheduler`], or [`PNDMScheduler`].
         safety_checker ([`StableDiffusionSafetyChecker`]):
             Classification module that estimates whether generated images could be considered offsensive or harmful.
-            Please, refer to the [model card](https://huggingface.co/CompVis/stable-diffusion-v1-4) for details.
+            Please, refer to the [model card](https://huggingface.co/runwayml/stable-diffusion-v1-5) for details.
         feature_extractor ([`CLIPFeatureExtractor`]):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
@@ -120,7 +120,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
         for i in range(num_ouputs):
             shape = exe_module.get_output_maximum_shape(i)
             ys.append(torch.empty(shape).cuda().half())
-        exe_module.run_with_tensors(inputs, ys, graph_mode=True)
+        exe_module.run_with_tensors(inputs, ys, graph_mode=False)
         noise_pred = ys[0].permute((0, 3, 1, 2)).float()
         return noise_pred
 
@@ -137,7 +137,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
         for i in range(num_ouputs):
             shape = exe_module.get_output_maximum_shape(i)
             ys.append(torch.empty(shape).cuda().half())
-        exe_module.run_with_tensors(inputs, ys, graph_mode=True)
+        exe_module.run_with_tensors(inputs, ys, graph_mode=False)
         return ys[0].float()
 
     def vae_inference(self, vae_input):
@@ -148,7 +148,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
         for i in range(num_ouputs):
             shape = exe_module.get_output_maximum_shape(i)
             ys.append(torch.empty(shape).cuda().half())
-        exe_module.run_with_tensors(inputs, ys, graph_mode=True)
+        exe_module.run_with_tensors(inputs, ys, graph_mode=False)
         vae_out = ys[0].permute((0, 3, 1, 2)).float()
         return vae_out
 

--- a/examples/05_stable_diffusion/pipeline_stable_diffusion_img2img_ait.py
+++ b/examples/05_stable_diffusion/pipeline_stable_diffusion_img2img_ait.py
@@ -70,7 +70,7 @@ class StableDiffusionImg2ImgAITPipeline(StableDiffusionImg2ImgPipeline):
             [`DDIMScheduler`], [`LMSDiscreteScheduler`], or [`PNDMScheduler`].
         safety_checker ([`StableDiffusionSafetyChecker`]):
             Classification module that estimates whether generated images could be considered offsensive or harmful.
-            Please, refer to the [model card](https://huggingface.co/CompVis/stable-diffusion-v1-4) for details.
+            Please, refer to the [model card](https://huggingface.co/runwayml/stable-diffusion-v1-5) for details.
         feature_extractor ([`CLIPFeatureExtractor`]):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
@@ -141,7 +141,7 @@ class StableDiffusionImg2ImgAITPipeline(StableDiffusionImg2ImgPipeline):
         for i in range(num_ouputs):
             shape = exe_module.get_output_maximum_shape(i)
             ys.append(torch.empty(shape).cuda().half())
-        exe_module.run_with_tensors(inputs, ys, graph_mode=True)
+        exe_module.run_with_tensors(inputs, ys, graph_mode=False)
         noise_pred = ys[0].permute((0, 3, 1, 2)).float()
         return noise_pred
 
@@ -158,7 +158,7 @@ class StableDiffusionImg2ImgAITPipeline(StableDiffusionImg2ImgPipeline):
         for i in range(num_ouputs):
             shape = exe_module.get_output_maximum_shape(i)
             ys.append(torch.empty(shape).cuda().half())
-        exe_module.run_with_tensors(inputs, ys, graph_mode=True)
+        exe_module.run_with_tensors(inputs, ys, graph_mode=False)
         return ys[0].float()
 
     def vae_inference(self, vae_input):
@@ -169,7 +169,7 @@ class StableDiffusionImg2ImgAITPipeline(StableDiffusionImg2ImgPipeline):
         for i in range(num_ouputs):
             shape = exe_module.get_output_maximum_shape(i)
             ys.append(torch.empty(shape).cuda().half())
-        exe_module.run_with_tensors(inputs, ys, graph_mode=True)
+        exe_module.run_with_tensors(inputs, ys, graph_mode=False)
         vae_out = ys[0].permute((0, 3, 1, 2)).float()
         return vae_out
 


### PR DESCRIPTION
* graph model off (#43)

Co-authored-by: Terry Chen <terrychen@meta.com>

* updated to 5th stable diffusion checkpoint (#57)

* updated to 5th stable diffusion checkpoint

* updated all stable diffusion example files to checkpoint v1.5

* Support different sizes via recompilation (StableDiff demo) (#71)

Mostly, this commit is just re-establishing the relationship between various previously-hardcoded constants and the target image size (since the latent size is 1/8 of the image size, hardcoding the latent sizes is inconvenient).

This adds `--width` and `--height` options to both compile.py and demo.py, and provided these both match you can process different sizes. For img2img mode, the size options passed at compile time must match the size of the actual input image.

Consequently, the `--img2img` flag for `compile.py` no longer exists: all this ever did was change the hardcoded size to match the default input image used by `demo_img2img.py`. Yikes.

Sooo it's slightly more flexible than before, but still has no support for a single binary to handle different image sizes. It isn't super clear that compiling a generic binary is useful: the upstream project can do that just fine: isn't the whole point of AITemplates to achieve performance gains via aggressive constant propagation and benchmarking to select the optimal kernels?

Co-authored-by: Terry Chen <hahakuku@hotmail.com>
Co-authored-by: Terry Chen <terrychen@meta.com>
Co-authored-by: Ivan Mikhnenkov <39604625+ivanmikhnenkov@users.noreply.github.com>
Co-authored-by: Chris Kitching <chriskitching@linux.com>